### PR TITLE
fix(valid_phone_number): correct logic to validate phone number format

### DIFF
--- a/6 kyu/valid_phone_number.js
+++ b/6 kyu/valid_phone_number.js
@@ -1,7 +1,11 @@
 function validPhoneNumber(phoneNumber) {
 	return phoneNumber.split(" ").length === 2
 		? phoneNumber.split("-").length === 2
+			? isNaN(Number(phoneNumber[1]))
+				? false
+				: true
+			: false
 		: false;
 }
 
-console.log(validPhoneNumber("abc(123) 456-7890)"));
+console.log(validPhoneNumber("(123) 456-7890"));


### PR DESCRIPTION
The previous implementation incorrectly validated phone numbers with non-numeric characters. This commit fixes the logic by adding a check to ensure the second character is a number, improving the accuracy of the validation.